### PR TITLE
Update templates to account for '/' and make module idempotent

### DIFF
--- a/templates/ensure.ps1.erb
+++ b/templates/ensure.ps1.erb
@@ -3,16 +3,16 @@ $shortcut = $shell.CreateShortcut("<%= @lnk_path %>")
 $shortcut.TargetPath = "<%= @target %>"
 
 <% unless @arguments.nil? -%>
-$shortcut.Arguments = "<%= @arguments.gsub(%r{/}, '\\') %>"
+$shortcut.Arguments = "<%= @arguments %>"
 <% end -%>
 <% unless @description.nil? -%>
-$shortcut.Description = "<%= @description.gsub(%r{/}, '\\') %>"
+$shortcut.Description = "<%= @description %>"
 <% end -%>
 <% unless @working_directory.nil? -%>
 $shortcut.WorkingDirectory = "<%= @working_directory.gsub(%r{/}, '\\') %>"
 <% end -%>
 <% unless @icon_location.nil? -%>
-$shortcut.IconLocation = "<%= @icon_location.gsub(%r{/}, '\\') %>"
+$shortcut.IconLocation = "<%= @icon_location %>"
 <% end -%>
 
 $shortcut.Save()

--- a/templates/exists.ps1.erb
+++ b/templates/exists.ps1.erb
@@ -1,17 +1,17 @@
 $shell = New-Object -COM WScript.Shell
 $shortcut = $shell.CreateShortcut("<%= @lnk_path %>")
 
-If (-Not ($shortcut.TargetPath -eq "<%= @target.gsub(%r{/}, '\\') %>")) { Exit 1 }
+If ( ($shortcut.TargetPath -eq "<%= @target.gsub(%r{/}, '\\') %>")) { Exit 0 }
 <% unless @arguments.nil? -%>
-If (-Not ($shortcut.Arguments -eq "<%= @arguments.gsub(%r{/}, '\\') %>")) { Exit 1 }
+If ( ($shortcut.Arguments -eq "<%= @arguments %>")) { Exit 0 }
 <% end -%>
 <% unless @description.nil? -%>
-If (-Not ($shortcut.Description -eq "<%= @description.gsub(%r{/}, '\\') %>")) { Exit 1 }
+If ( ($shortcut.Description -eq "<%= @description %>")) { Exit 0 }
 <% end -%>
 <% unless @working_directory.nil? -%>
-If (-Not ($shortcut.WorkingDirectory -eq "<%= @working_directory.gsub(%r{/}, '\\') %>")) { Exit 1 }
+If ( ($shortcut.WorkingDirectory -eq "<%= @working_directory.gsub(%r{/}, '\\') %>")) { Exit 0 }
 <% end -%>
 <% unless @icon_location.nil? -%>
-If (-Not ($shortcut.IconLocation -eq "<%= @icon_location.gsub(%r{/}, '\\') %>")) { Exit 1 }
+If ( ($shortcut.IconLocation -eq "<%= @icon_location %>")) { Exit 0 }
 <% end -%>
-Exit 0
+Exit 1


### PR DESCRIPTION
Currently module will replace '/' with '\\', assuming that we're normalizing file and directory structure, but for windows shortcuts, switches take the form of '/{switch}' so we were flipping the slash, causing the switch to not work.

In addition, module was not idempotent because the unless and exists templates weren't exiting properly. Updated to make idempotent.